### PR TITLE
Add API docs page

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -6,7 +6,7 @@
 <p>lang - The language of the insult you want. Defaults to <code>English</code> if not provided</p>
 </li>
 <li>
-<p>type - The response type. It supports <code>text</code>, <code>XML</code> and <code>JSON</code>. Defaults to <code>plain text</code> if not provided.</p>
+<p>type - The response type. It supports <code>text</code>, <code>XML</code> and <code>JSON</code>. Defaults to <code>plain text</code> if not provided</p>
 </li>
 </ul>
 <h4>Example URI</h4><div class="definition"><span class="uri"><pre><code class="language-no-highlight">https://evilinsult.com/generate_insult.php?lang=en&type=json</code></pre></span></div><div class="title"><strong>Response&nbsp;&nbsp;<code>200</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{


### PR DESCRIPTION
## Description
This adds the API docs page for the evil insult generator API.

## Screenshops
<img width="1305" alt="screen shot 2018-10-25 at 10 21 14" src="https://user-images.githubusercontent.com/20906768/47544478-e7a60280-d8ef-11e8-830e-d7e4e483209f.png">
