### PR TITLE
🐛 Add Content-Type for JSON

### DIFF
--- a/generate_insult.php
+++ b/generate_insult.php
@@ -47,6 +47,8 @@ if (empty($result)) {
     $upcnt->execute();
     switch ($type) {
         case "json":
+            Header('Content-type: application/json');
+            
             echo json_encode($filtered);
             break;
         case "plain":


### PR DESCRIPTION
Add the missing Content-Type header for the json option

Was going to add one to the default case also, but I suppose its not necessary.

