### PR TITLE
🐎 Modify $sql_insult to reference column names

### DIFF
--- a/db.conf.php
+++ b/db.conf.php
@@ -5,7 +5,23 @@ $dbconfig['base'] = 'YOURDB';
 $dbconfig['pass'] = 'YOURDBPASS';
 $dbconfig['char'] = 'utf8';
 $active_insult = 1;
-$sql_insult = "SELECT * FROM insults WHERE number >= RAND() * (SELECT MAX(number) FROM insults WHERE active = :active and language = :lang ) AND language = :lang AND active = :active ORDER BY number LIMIT 1";
+
+$sql_insult = "SELECT 
+    number,
+    language,
+    insult,
+    created,
+    shown,
+    createdby,
+    active,
+    comment
+FROM insults 
+WHERE number >= RAND() * (SELECT MAX(number) FROM insults WHERE active = :active and language = :lang ) 
+    AND language = :lang 
+    AND active = :active
+ORDER BY number LIMIT 1;
+";
+
 $update_counter = "UPDATE insults SET shown = shown + 1 WHERE number = :number";
 
 


### PR DESCRIPTION
This is a optimization for SQL. 

When doing a `SELECT *` SQL has to regenerate the query plan. In addition to this an extra cycle is required for SQL to get the column names.

By defining the columns explicitly you can save a few micro seconds. (An optimization is an optimization 😁👍)

I haven't checked what column names are actually used past this point, so we could also remove any columns that aren't referenced. That can also help.  